### PR TITLE
Mongo driver 1.0.8 deprecates ObjectID for ObjectId

### DIFF
--- a/lib/sunspot/mongoid.rb
+++ b/lib/sunspot/mongoid.rb
@@ -36,8 +36,9 @@ module Sunspot
       end
 
       def load_all(ids)
-        @clazz.where(:_id.in => ids.map { |id| BSON::ObjectID.from_string(id) })
+        @clazz.where(:_id.in => ids.map { |id| BSON::ObjectId.from_string(id) })
       end
+      
     end
   end
 end


### PR DESCRIPTION
I've patched your gem, wanna pull ?
