### PR TITLE
Allow for object keys that aren't BSON::ObjectId

### DIFF
--- a/lib/sunspot/mongoid.rb
+++ b/lib/sunspot/mongoid.rb
@@ -32,11 +32,19 @@ module Sunspot
 
     class DataAccessor < Sunspot::Adapters::DataAccessor
       def load(id)
-        @clazz.find(BSON::ObjectID.from_string(id)) rescue nil
+		if @clazz.using_object_ids? then
+			@clazz.find(BSON::ObjectID.from_string(id)) rescue nil
+		else
+			@clazz.find(id) rescue nil
+		end
       end
 
       def load_all(ids)
-        @clazz.where(:_id.in => ids.map { |id| BSON::ObjectId.from_string(id) })
+		if @clazz.using_object_ids? then
+			@clazz.where(:_id.in => ids.map { |id| BSON::ObjectId.from_string(id) })
+		else
+			@clazz.where(:_id.in => ids)
+		end
       end
       
     end


### PR DESCRIPTION
Thanks for this code, helped me get solr/mongo up fast.

When I changed my object key to an internal string - eg.

  include Mongoid::Document
  field :kid, :type => String
  key :kid

The call to
 @search.each_hit_with_result do |hit, entry| 
resulted in a error
ActionView::Template::Error (illegal ObjectId format):

This change fixes it by checking whether we are using object_ids
https://github.com/mongoid/mongoid/blob/master/lib/mongoid/keys.rb#L30-43
