### PR TITLE
uninitialized constant BSON::ObjectId

### DIFF
--- a/lib/sunspot/mongoid.rb
+++ b/lib/sunspot/mongoid.rb
@@ -32,13 +32,18 @@ module Sunspot
 
     class DataAccessor < Sunspot::Adapters::DataAccessor
       def load(id)
-        @clazz.find(BSON::ObjectID.from_string(id)) rescue nil
+        criteria(id).first
       end
 
       def load_all(ids)
-        @clazz.where(:_id.in => ids.map { |id| BSON::ObjectId.from_string(id) })
+        criteria(ids)
       end
-      
+
+      private
+
+      def criteria(id)
+        @clazz.criteria.id(id)
+      end
     end
   end
 end


### PR DESCRIPTION
- fixes uninitialized constant BSON::ObjectId (occur at least with mongoid 2.0.0.beta.16)
- fixes https://github.com/jugyo/sunspot_mongoid/pull/10
- cleans up criteria logic
- works with mongoid 2.2.0 as well
